### PR TITLE
polyfill.io を導入して IE11 対応

### DIFF
--- a/api-status.js
+++ b/api-status.js
@@ -62,7 +62,7 @@ function getStatuses(serverList) {
 	});
 }
 
-function getA(href, type = null, content = null) {
+function getA(href, type, content) {
 	var a = document.createElement('a');
 	a.innerHTML = content ? content : href;
 	switch(type) {
@@ -108,7 +108,7 @@ function toClipBoard(text) {
 }
 
 function outputList(servers) {
-	for (const server of servers) {
+	servers.forEach(function (server) {
 		var tdServerName = document.createElement('td');
 		tdServerName.classList.add('server-name');
 		tdServerName.textContent = server;
@@ -136,7 +136,7 @@ function outputList(servers) {
 
 		var table = document.getElementById('versions');
 		table.appendChild(tr);
-	}
+	});
 }
 
 function getVersions() {
@@ -275,8 +275,9 @@ function getLatestRelease() {
 	return Promise.all(promises);
 }
 
-function createFontAwesomeIcon(style, prefix = 'far ') {
+function createFontAwesomeIcon(style, prefix) {
+	if (!prefix) prefix = "far ";
 	var icon = document.createElement('i');
 	icon.className = prefix + style;
 	return icon;
-};
+}

--- a/index.html
+++ b/index.html
@@ -10,6 +10,10 @@
 	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css">
 	<link rel="stylesheet" href="styles.css">
 	<link rel="icon" type="image/png" href="https://bcdice.org/image/bcdice-logo.png">
+
+	<script src="https://polyfill.io/v3/polyfill.min.js?features=es2019" defer></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.14.0/js-yaml.min.js" integrity="sha512-ia9gcZkLHA+lkNST5XlseHz/No5++YBneMsDp1IZRJSbi1YqQvBeskJuG1kR+PH1w7E0bFgEZegcj0EwpXQnww==" crossorigin="anonymous" defer></script>
+	<script src="api-status.js" defer></script>
 </head>
 
 <body>
@@ -60,8 +64,5 @@
 			<p>&copy; 2020 BCDice Project</p>
 		</footer>
 	</article>
-
-	<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.7.0/js-yaml.min.js"></script>
-	<script type="text/javascript" src="api-status.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" href="styles.css">
 	<link rel="icon" type="image/png" href="https://bcdice.org/image/bcdice-logo.png">
 
-	<script src="https://polyfill.io/v3/polyfill.min.js?features=es2019" defer></script>
+	<script src="https://polyfill.io/v3/polyfill.min.js?features=es2019%2Cfetch" defer></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.14.0/js-yaml.min.js" integrity="sha512-ia9gcZkLHA+lkNST5XlseHz/No5++YBneMsDp1IZRJSbi1YqQvBeskJuG1kR+PH1w7E0bFgEZegcj0EwpXQnww==" crossorigin="anonymous" defer></script>
 	<script src="api-status.js" defer></script>
 </head>


### PR DESCRIPTION
fix #11 

# 概要
IE11 対応しつつ [polyfill.io](http://polyfill.io/) を導入してみました。 

動作確認環境
- OS: Windows10
- ブラウザ: IE11, Chrome, Firefox, Edge Legacy

## IE11 対応
- `for ... of` を `Array#forEach` で書き換え https://caniuse.com/#feat=mdn-javascript_statements_for_of_closing_iterators
- default parameter を廃止 https://caniuse.com/#feat=mdn-javascript_functions_default_parameters

## Fetch API の使用
XMLHttpRequest を fetch/Promise で書き換えました。
ただ、 async/await は使用できなかったので、逆にややこしくなってしまったかもしれません。

- Fetch API には Timeout の設定が無いため、 Timeout 表示の処理を削除しました

## IE, Edge Legacy 特有の現象
https://bcdice.kiridaruma.net がうまく読み込めないようで、fetchでエラーが出ます。
クライアント側の問題では無い気がします。
![image](https://user-images.githubusercontent.com/7685946/87216365-01b09e80-c37a-11ea-8c39-80686cadad7b.png)


